### PR TITLE
Implement functionality in the Profile Screen

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,5 +1,3 @@
-// TODO: Paginate network requests
-
 export const fetchFollowers = async (username, page = 1) => {
   try {
     const response = await fetch(

--- a/src/screens/FollowersList.js
+++ b/src/screens/FollowersList.js
@@ -58,6 +58,9 @@ const FollowersList = ({ actions, appUser, followers, navigation, route }) => {
   useEffect(() => {
     if (profileUserName.length > 0) {
       setIsNewFollowersLoading(true);
+      setIsLoading(false);
+      setIsListEnd(false);
+      setPage(2);
       actions
         .loadFollowers(profileUserName)
         .then(() => setIsNewFollowersLoading(false))
@@ -98,7 +101,10 @@ const FollowersList = ({ actions, appUser, followers, navigation, route }) => {
       setIsLoading(true);
 
       try {
-        const newFollowers = await fetchFollowers(appUser.username, page);
+        const newFollowers =
+          profileUserName.length > 0
+            ? await fetchFollowers(profileUserName, page)
+            : await fetchFollowers(appUser.username, page);
 
         if (newFollowers.length === 0) {
           /*

--- a/src/screens/FollowersList.js
+++ b/src/screens/FollowersList.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Dimensions,
@@ -41,10 +41,32 @@ const Item = ({ login, avatarUrl, navigation }) => {
   );
 };
 
-const FollowersList = ({ actions, appUser, followers, navigation }) => {
+const FollowersList = ({ actions, appUser, followers, navigation, route }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [isListEnd, setIsListEnd] = useState(false);
   const [page, setPage] = useState(2);
+  const [profileUserName, setProfileUserName] = useState('');
+  const [isNewFollowersLoading, setIsNewFollowersLoading] = useState(false);
+
+  useEffect(() => {
+    if (route.params) {
+      const { username } = route.params;
+      setProfileUserName(username);
+    }
+  }, [route]);
+
+  useEffect(() => {
+    if (profileUserName.length > 0) {
+      setIsNewFollowersLoading(true);
+      actions
+        .loadFollowers(profileUserName)
+        .then(() => setIsNewFollowersLoading(false))
+        .catch((error) => {
+          setIsNewFollowersLoading(false);
+          console.log(error);
+        });
+    }
+  }, [profileUserName, actions]);
 
   const renderItem = ({ item }) => {
     if (item.empty === true) {
@@ -105,17 +127,29 @@ const FollowersList = ({ actions, appUser, followers, navigation }) => {
         <NoFollowers />
       ) : (
         <>
-          <Text style={styles.appUserName}>{appUser.username}</Text>
-          <FlatList
-            data={formatGridData(followers, NUM_OF_COLUMNS)}
-            renderItem={renderItem}
-            ListFooterComponent={renderListFooter}
-            keyExtractor={(item) => String(item.id)}
-            horizontal={false}
-            numColumns={NUM_OF_COLUMNS}
-            onEndReachedThreshold={0.5}
-            onEndReached={loadMoreResults}
-          />
+          {isNewFollowersLoading ? (
+            <View style={styles.screenSpinnerContainer}>
+              <ActivityIndicator color={colors.green} size="large" />
+            </View>
+          ) : (
+            <>
+              <Text style={styles.appUserName}>
+                {profileUserName.length > 0
+                  ? profileUserName
+                  : appUser.username}
+              </Text>
+              <FlatList
+                data={formatGridData(followers, NUM_OF_COLUMNS)}
+                renderItem={renderItem}
+                ListFooterComponent={renderListFooter}
+                keyExtractor={(item) => String(item.id)}
+                horizontal={false}
+                numColumns={NUM_OF_COLUMNS}
+                onEndReachedThreshold={0.5}
+                onEndReached={loadMoreResults}
+              />
+            </>
+          )}
         </>
       )}
     </View>
@@ -132,6 +166,10 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     actions: {
+      loadFollowers: bindActionCreators(
+        followerActions.loadFollowers,
+        dispatch,
+      ),
       updateFollowers: bindActionCreators(
         followerActions.updateFollowers,
         dispatch,
@@ -180,6 +218,11 @@ const styles = StyleSheet.create({
   },
   listFooterSpinner: {
     margin: 5,
+  },
+  screenSpinnerContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    flex: 1,
   },
 });
 

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -17,7 +17,7 @@ import colors from '../constants/colors';
 import { FollowersContext } from '../contexts/FollowersContext';
 import * as userActions from '../redux/actions/userActions';
 
-const Profile = ({ actions, user }) => {
+const Profile = ({ actions, navigation, user }) => {
   const { userLogin: username } = useContext(FollowersContext);
 
   useEffect(() => {
@@ -115,7 +115,16 @@ const Profile = ({ actions, user }) => {
             </View>
           </View>
 
-          <TouchableOpacity style={[styles.btn, styles.btnFollowers]}>
+          <TouchableOpacity
+            style={[styles.btn, styles.btnFollowers]}
+            onPress={
+              () =>
+                navigation.navigate('Followers list', {
+                  username,
+                })
+              // eslint-disable-next-line react/jsx-curly-newline
+            }
+          >
             <Text style={styles.btnText}>Get Followers</Text>
           </TouchableOpacity>
         </View>

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -3,6 +3,7 @@ import { Entypo, Feather, Ionicons, SimpleLineIcons } from '@expo/vector-icons';
 import { format } from 'date-fns';
 import React, { useContext, useEffect } from 'react';
 import {
+  Image,
   ScrollView,
   StyleSheet,
   Text,
@@ -30,7 +31,10 @@ const Profile = ({ actions, user }) => {
       <View style={styles.container}>
         {/* PROFILE */}
         <View style={styles.profile}>
-          <View style={styles.profileImagePlaceholder} />
+          <Image
+            source={{ uri: `${user.avatar_url}` }}
+            style={styles.profileImage}
+          />
           <View style={styles.profileDetails}>
             <Text style={styles.profileLogin}>{user.login}</Text>
             <Text style={styles.profileText}>{user.name}</Text>
@@ -151,14 +155,14 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     paddingVertical: 15,
-    paddingHorizontal: 30,
+    paddingHorizontal: 20,
     backgroundColor: colors.white,
   },
   profile: {
     flexDirection: 'row',
     marginBottom: 15,
   },
-  profileImagePlaceholder: {
+  profileImage: {
     width: 120,
     height: 120,
     borderRadius: 10,

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -3,7 +3,9 @@ import { Entypo, Feather, Ionicons, SimpleLineIcons } from '@expo/vector-icons';
 import { format } from 'date-fns';
 import React, { useContext, useEffect } from 'react';
 import {
+  Alert,
   Image,
+  Linking,
   ScrollView,
   StyleSheet,
   Text,
@@ -16,6 +18,12 @@ import { bindActionCreators } from 'redux';
 import colors from '../constants/colors';
 import { FollowersContext } from '../contexts/FollowersContext';
 import * as userActions from '../redux/actions/userActions';
+
+const openUrl = (url) => {
+  return Linking.openURL(url).catch(() => {
+    Alert.alert('Sorry, something went wrong.', 'Please try again later');
+  });
+};
 
 const Profile = ({ actions, navigation, user }) => {
   const { userLogin: username } = useContext(FollowersContext);
@@ -80,7 +88,10 @@ const Profile = ({ actions, navigation, user }) => {
             </View>
           </View>
 
-          <TouchableOpacity style={[styles.btn, styles.btnProfile]}>
+          <TouchableOpacity
+            style={[styles.btn, styles.btnProfile]}
+            onPress={() => openUrl(`https://github.com/${user.login}`)}
+          >
             <Text style={styles.btnText}>GitHub Profile</Text>
           </TouchableOpacity>
         </View>


### PR DESCRIPTION
# Implement functionality in the Profile Screen

Add functionality to these two buttons when pressed:

- GitHub Profile
- Get Followers

## Tasks

- [x] On pressing the **GitHub Profile** button, navigate to a web page that displays the user's GitHub profile details
- [x] On pressing the **Get Followers** button, navigate to the followers' list screen and display that particular users' followers
- [x] Solve the image not displaying issue. Check out this issue, <https://github.com/khwilo/GitHubFollowers/issues/9>, for more details.

## TODO

- [x] Update the username to use while loading more followers from the network
- [x] Revert the loading states to their original value when a user navigates from the Profile Screen

## Demo

![profile-logic](https://user-images.githubusercontent.com/5740429/100585812-3a3c1f00-32ff-11eb-97ed-56743b6f8193.gif)
